### PR TITLE
Use file id to update file statuses

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   lazy val s3Utils = "uk.gov.nationalarchives" %% "s3-utils" % awsUtilsVersion
   lazy val ssmUtils = "uk.gov.nationalarchives" %% "ssm-utils" % awsUtilsVersion
   lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.305"
-  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.479"
+  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.480"
   lazy val awsLambdaCore = "com.amazonaws" % "aws-lambda-java-core" % "1.4.0"
   lazy val awsLambdaEvents = "com.amazonaws" % "aws-lambda-java-events" % "3.16.1"
   lazy val awsSqs = "com.amazonaws" % "aws-java-sdk-sqs" % "1.12.797"

--- a/src/main/scala/uk/gov/nationalarchives/externalevent/events/DR2EventHandler.scala
+++ b/src/main/scala/uk/gov/nationalarchives/externalevent/events/DR2EventHandler.scala
@@ -9,7 +9,7 @@ import uk.gov.nationalarchives.aws.utils.s3.{S3Clients, S3Utils}
 import uk.gov.nationalarchives.externalevent.GraphQlApi
 import uk.gov.nationalarchives.externalevent.decoders.DR2EventDecoder.DR2Event
 import uk.gov.nationalarchives.tdr.common.utils.objectkeycontext.Context
-import uk.gov.nationalarchives.tdr.common.utils.objectkeycontext.ObjectTypes.Metadata
+import uk.gov.nationalarchives.tdr.common.utils.objectkeycontext.ObjectTypes.{Metadata, Record}
 
 import scala.concurrent.ExecutionContext
 import scala.util.Try
@@ -34,8 +34,8 @@ object DR2EventHandler {
         case Left(err) => logger.log(s"Error adding tags to $key: ${err.getMessage}", LogLevel.ERROR)
         case Right(_)  =>
           logger.log(s"Tags added successfully to $key", LogLevel.INFO)
-          if (objectContext.objectType.get == Metadata) {
-            updateFileStatus(objectContext.assetId.get.toString, tags.head._1, tags.head._2, doUpdate)
+          if (objectContext.objectType.get == Record) {
+            updateFileStatus(objectContext.fileId.get.toString, tags.head._1, tags.head._2, doUpdate)
           }
       }).recover { case e: Exception =>
         logger.log(s"An error occurred while adding tags to $key: ${e.getMessage}", LogLevel.ERROR)

--- a/src/main/scala/uk/gov/nationalarchives/externalevent/events/DR2EventHandler.scala
+++ b/src/main/scala/uk/gov/nationalarchives/externalevent/events/DR2EventHandler.scala
@@ -9,7 +9,7 @@ import uk.gov.nationalarchives.aws.utils.s3.{S3Clients, S3Utils}
 import uk.gov.nationalarchives.externalevent.GraphQlApi
 import uk.gov.nationalarchives.externalevent.decoders.DR2EventDecoder.DR2Event
 import uk.gov.nationalarchives.tdr.common.utils.objectkeycontext.Context
-import uk.gov.nationalarchives.tdr.common.utils.objectkeycontext.ObjectTypes.{Metadata, Record}
+import uk.gov.nationalarchives.tdr.common.utils.objectkeycontext.ObjectTypes.Record
 
 import scala.concurrent.ExecutionContext
 import scala.util.Try

--- a/src/test/scala/uk/gov/nationalarchives/externalevent/DR2IntegrationSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/externalevent/DR2IntegrationSpec.scala
@@ -117,7 +117,8 @@ class DR2IntegrationSpec extends ExternalServicesSpec with Matchers {
   }
 
   "DR2EventHandler" should "send file status updates to the API for asset" in {
-    mockS3ListResponse(prefix = prefixUUID, files = List(file1UUID, file2UUID, file3UUID))
+    val fileIds = List(file1UUID, file2UUID, file3UUID)
+    mockS3ListResponse(prefix = prefixUUID, files = fileIds)
     mockS3GetTaggingResponse()
     mockS3PutResponse()
     authOk()
@@ -126,7 +127,7 @@ class DR2IntegrationSpec extends ExternalServicesSpec with Matchers {
 
     val serveEvents = wiremockGraphql.getAllServeEvents.asScala
     val fileStatusUpdates = serveEvents.filter(_.getRequest.getBodyAsString.contains("addMultipleFileStatuses"))
-    fileStatusUpdates.size should be(1)
+    fileStatusUpdates.size should be(fileIds.size)
   }
 
   def runEventHandler(eventType: String, updateFileStatus: Boolean = false): DR2EventDecoder.DR2Event = {


### PR DESCRIPTION
TDR persists the an asset id, and no longer uses the TDR file id as the asset id

Internally with in the TDR DB the TDR file id is used as the primary identifier for a record as it still maintains a 1 to 1 relationship between record and digital object

The AWS S3 keys for the digital object are now in the form: {persist asset id}/{tdr file id}

To update the file status still need to use the TDR file id value from the Key until TDR's internal model is updated to supprt 1 to many digital objects for a record. See ticket: https://national-archives.atlassian.net/browse/TDRD-1468